### PR TITLE
feat: API 서버 도메인 적용 및 로컬 실행환경 분리

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,9 @@
 app-build:
 	docker-compose build
 
+local-app-up:
+	docker-compose -f docker-compose.dev.yml up -d
+
 app-up:
 	docker-compose up -d
 

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -18,7 +18,7 @@ services:
       - oknawa-network
     labels:
       - traefik.http.routers.fastapi.entrypoints=websecure
-      - traefik.http.routers.fastapi.rule=Host(`api.oknawa.com`)
+      - traefik.http.routers.fastapi.rule=Host(`api-127-0-0-1.traefik.me`)
       - traefik.http.routers.fastapi.tls=true
       - traefik.http.routers.fastapi.tls.certresolver=letsencrypt
   
@@ -39,7 +39,7 @@ services:
       - --entrypoints.web.address=:80
       - --entrypoints.web.http.redirections.entryPoint.to=websecure
       - --entrypoints.web.http.redirections.entryPoint.scheme=https
-      - --entrypoints.web.http.redirections.entrypoint.permanent=true"     
+      - --entrypoints.web.http.redirections.entrypoint.permanent=true
       - --entrypoints.websecure.address=:443
       - --certificatesresolvers.letsencrypt.acme.httpchallenge=true
       - --certificatesresolvers.letsencrypt.acme.httpchallenge.entrypoint=web
@@ -47,7 +47,7 @@ services:
       - --certificatesresolvers.letsencrypt.acme.storage=/letsencrypt/acme.json
     labels:
       # Dashboard
-      - traefik.http.routers.traefik.rule=Host(`traefik.oknawa.com`)
+      - traefik.http.routers.traefik.rule=Host(`traefik-127-0-0-1.traefik.me`)
       - traefik.http.routers.traefik.service=api@internal
       - traefik.http.routers.traefik.middlewares=admin
       - traefik.http.routers.traefik.tls.certresolver=letsencrypt


### PR DESCRIPTION
<br>

## PR 유형

- [x] 기능 개발
- [ ] 버그 수정
- [x] 리팩토링(기능 변경 없음, API 변경 없음)
- [ ] 코드 스타일 업데이트(포매팅, 지역 변수 등)
- [ ] 문서 내용 수정
- [ ] 기타(설명해주세요) :


## 세부 내용

- api.oknawa.com, traefik.oknawa.com 으로 주소 변경했습니다.
  - aws route 53 설정 했습니다. ssl인증서도 aws로 할지말지 모르겠어서 일단 도메인만 적용해놨습니다. :)
- 로컬환경과 배포서버환경을 컴포즈파일을 나눠 실행하게 변경했습니다.
  - local : make local-app-up, depoly : make app-up



## 체크리스트

- [x] 내 코드에 대한 자체 검토를 수행했습니다.
- [x] 내 코드는 이 프로젝트의 스타일 가이드라인을 따릅니다.
- [x] 핵심 기능이라면 철저한 테스트를 추가했습니다.
- [x] 내 변경 사항이 새로운 경고를 생성하지 않습니다.
