### PR TITLE
fix: 중간 지점 찾기 api에 priority를 query param으로 추가

### DIFF
--- a/app/core/util/distance_calculator.py
+++ b/app/core/util/distance_calculator.py
@@ -25,27 +25,28 @@ def get_center_coordinates(body):
     return center_coordinates
 
 
-def get_center_location(center_coordinates, popular_location_in_db):
+def get_center_location(center_coordinates, popular_location_in_db, priority):
     """중간지점좌표와 인기있는역의 거리계산후 가장가까운 역 리턴
 
     Args:
         center_coordinates (tuple): (중간지점x좌표, 중간지점y좌표)
         popular_location_in_db (obj): db의 인기있는역 데이터
+        priority(int): n번째로 가까운 지역
 
     Returns:
-        dict: place_list의 요소 중간지점좌표와 가장가까운 역
+        dict: 인기 있는역 데이터의 요소 중 중간지점좌표와 n번째로 가까운 지역
     """
     center_x, center_y = center_coordinates
-    largest_distance = float("inf")
-    center_location = None
+    location = []
 
-    for location in popular_location_in_db:
-        location_x = float(location.location_x)
-        location_y = float(location.location_y)
+    for popular_location in popular_location_in_db:
+        location_x = float(popular_location.location_x)
+        location_y = float(popular_location.location_y)
         current_distance = math.sqrt(
             (center_x - location_x) ** 2 + (center_y - location_y) ** 2
         )
-        if current_distance < largest_distance:
-            largest_distance = current_distance
-            center_location = location
-    return center_location
+        location.append((current_distance, popular_location))
+
+    sorted_locations = sorted(location, key=lambda x: x[0])
+
+    return sorted_locations[priority][1]

--- a/app/routers/location.py
+++ b/app/routers/location.py
@@ -1,6 +1,6 @@
 from typing import Literal
 
-from fastapi import APIRouter, BackgroundTasks, Depends, Path
+from fastapi import APIRouter, BackgroundTasks, Depends, Path, Query
 from redis import Redis
 from sqlalchemy.orm import Session
 
@@ -21,10 +21,11 @@ router = APIRouter(prefix="/location", tags=[RouterTags.location])
 )
 def post_location_point(
     body: req_location.PostLocationPoint,
+    priority: int = Query(default=0, ge=0, le=4, title="n번째 가까운 위치", description="n번째 가까운 위치"),
     db: Session = Depends(get_db),
     redis: Redis = Depends(get_redis),
 ):
-    return service_location.post_location_point(body, db, redis)
+    return service_location.post_location_point(body, priority, db, redis)
 
 
 @router.get(

--- a/app/services/location.py
+++ b/app/services/location.py
@@ -13,7 +13,7 @@ from app.crud import location
 from app.models.location import PopularMeetingLocation
 
 
-def post_location_point(body, db, redis):
+def post_location_point(body, priority, db, redis):
     """
         사용자들의 좌표를 받아 중간지점좌표와 가장가까운 역의 좌표를 구한 뒤
         tmap의 API를 이용하여 소요시간, 가는경로를 구하여 리턴 (도보 - 대중교통 - 도보)
@@ -24,6 +24,7 @@ def post_location_point(body, db, redis):
 
     Args:
         body (obj): /point의 request로 받은 유저별 좌표
+        priority(int): n번째로 가까운 지역
         db: get_db
         redis: get_redis
 
@@ -34,7 +35,7 @@ def post_location_point(body, db, redis):
     popular_location_in_db = location.get_popular_meeting_location_all(db)
     center_coordinates = distance_calculator.get_center_coordinates(body_data)
     center_location_data = distance_calculator.get_center_location(
-        center_coordinates, popular_location_in_db
+        center_coordinates, popular_location_in_db, priority
     )
     participant_itinerary = open_api.call_tmap_api_participant_itinerary(
         body, center_location_data


### PR DESCRIPTION
<br>

## PR 유형

- [x] 기능 개발
- [ ] 버그 수정
- [ ] 리팩토링(기능 변경 없음, API 변경 없음)
- [ ] 코드 스타일 업데이트(포매팅, 지역 변수 등)
- [ ] 문서 내용 수정
- [ ] 기타(설명해주세요) :


## 세부 내용

- 기존에는 사용자들 간의 거리에서 중간 좌표를 계산하여, db안에 지하철 역 중 가장 가까운 위치를 반환하였습니다.
- 이번 수정 사항은 priority를 query param으로 받아 n번째 가장 가까운 위치를 반환할 수 있도록 수정하였습니다.
- frontend의 수정사항을 최소화하기 위해, priority의 default를 값을 적용했고 priority가 query param으로 전달되지 않으면 가장 가까운 거리를 반환합니다.
- 또한 priority는 0부터 4까지 숫자만 가능하게하여, 최대 5개까지 가까운 지역을 확인해볼 수 있도록 적용했습니다.


## 체크리스트

- [x] 내 코드에 대한 자체 검토를 수행했습니다.
- [x] 내 코드는 이 프로젝트의 스타일 가이드라인을 따릅니다.
- [x] 핵심 기능이라면 철저한 테스트를 추가했습니다.
- [x] 내 변경 사항이 새로운 경고를 생성하지 않습니다.
